### PR TITLE
Always pass to UIView's designated initializer

### DIFF
--- a/Source/ICGVideoTrimmerView.m
+++ b/Source/ICGVideoTrimmerView.m
@@ -42,12 +42,7 @@
 
 - (instancetype)initWithAsset:(AVAsset *)asset
 {
-    self = [super init];
-    if (self) {
-        _asset = asset;
-        [self resetSubviews];
-    }
-    return self;
+    return [self initWithFrame:CGRectZero asset:asset];
 }
 
 - (instancetype)initWithFrame:(CGRect)frame asset:(AVAsset *)asset


### PR DESCRIPTION
`initWithAsset:` should call `UIView`'s designated initializer, `initWithFrame:` at some point.