### PR TITLE
VideoTrimmerView clips to bounds.

### DIFF
--- a/Source/ICGVideoTrimmerView.m
+++ b/Source/ICGVideoTrimmerView.m
@@ -76,6 +76,8 @@
 
 - (void)resetSubviews
 {
+    self.clipsToBounds = YES;
+
     [self setBackgroundColor:[UIColor blackColor]];
 
     [self.subviews makeObjectsPerformSelector:@selector(removeFromSuperview)];


### PR DESCRIPTION
Content and subviews need to be clipped to the bounds of the view.
Let's say a VideoTrimmerView in AViewController, after AViewController is pushed by BViewController, when we need to pop AViewController, there is a bug, VideoTrimmerView's subviews are out of bounds of AViewController.view.